### PR TITLE
fail2ban ssh/ssh-ddos and sasl are now sshd and postfix-sasl (fixes #…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+In Development
+--------------
+
+System:
+
+* Missing brute force login attack prevention (fail2ban) filters which stopped working on Ubuntu 18.04 were added back.
+
 v0.40 (January 12, 2019)
 ------------------------
 

--- a/conf/fail2ban/filter.d/miab-owncloud.conf
+++ b/conf/fail2ban/filter.d/miab-owncloud.conf
@@ -3,5 +3,6 @@
 before = common.conf
 
 [Definition]
+datepattern = %%Y-%%m-%%d %%H:%%M:%%S
 failregex=Login failed: .*Remote IP: '<HOST>[\)']
 ignoreregex =

--- a/conf/fail2ban/jails.conf
+++ b/conf/fail2ban/jails.conf
@@ -69,13 +69,10 @@ action   = iptables-allports[name=recidive]
 # So the notification is ommited. This will prevent message appearing in the mail.log that mail
 # can't be delivered to fail2ban@$HOSTNAME.
 
-[sasl]
+[postfix-sasl]
 enabled  = true
 
-[ssh]
+[sshd]
 enabled = true
 maxretry = 7
 bantime = 3600
-
-[ssh-ddos]
-enabled  = true

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -339,6 +339,7 @@ systemctl restart systemd-resolved
 
 # Configure the Fail2Ban installation to prevent dumb bruce-force attacks against dovecot, postfix, ssh, etc.
 rm -f /etc/fail2ban/jail.local # we used to use this file but don't anymore
+rm -f /etc/fail2ban/jail.d/defaults-debian.conf # removes default config so we can manage all of fail2ban rules in one config
 cat conf/fail2ban/jails.conf \
 	| sed "s/PUBLIC_IP/$PUBLIC_IP/g" \
 	| sed "s#STORAGE_ROOT#$STORAGE_ROOT#" \


### PR DESCRIPTION
…1453, merges #1454)

* fail2ban ssh/ssh-ddos and sasl are now sshd and postfix-sasl

* specified custom datepattern for miab-owncloud.conf